### PR TITLE
Export tryfrom

### DIFF
--- a/src/derives.rs
+++ b/src/derives.rs
@@ -1,0 +1,56 @@
+pub trait TryFrom<Src> {
+    type Err;
+    fn try_from(src: Src) -> Result<Self, Self::Err>;
+}
+
+#[macro_export]
+macro_rules! TryFrom {
+    (($prim:ty) $(pub)* enum $name:ident { $($body:tt)* }) => {
+        TryFrom! {
+            @collect_variants ($name, $prim),
+            ($($body)*,) -> ()
+        }
+    };
+
+    (
+        @collect_variants ($name:ident, $prim:ty),
+        ($(,)*) -> ($($var_names:ident,)*)
+    ) => {
+        impl $crate::TryFrom<$prim> for $name {
+            type Err = $prim;
+            fn try_from(src: $prim) -> Result<$name, $prim> {
+                $(
+                    if src == $name::$var_names as $prim {
+                        return Ok($name::$var_names);
+                    }
+                )*
+                Err(src)
+            }
+        }
+    };
+
+    (
+        @collect_variants $fixed:tt,
+        ($var:ident $(= $_val:expr)*, $($tail:tt)*) -> ($($var_names:tt)*)
+    ) => {
+        TryFrom! {
+            @collect_variants $fixed,
+            ($($tail)*) -> ($($var_names)* $var,)
+        }
+    };
+
+    (
+        @collect_variants ($name:ident),
+        ($var:ident $_struct:tt, $($tail:tt)*) -> ($($var_names:tt)*)
+    ) => {
+        const _error: () = concat!(
+            "cannot derive TryFrom for ",
+            stringify!($name),
+            ", due to non-unitary variant ",
+            stringify!($var),
+            "."
+        );
+    };
+}
+
+

--- a/src/derives.rs
+++ b/src/derives.rs
@@ -1,9 +1,29 @@
+/// Trait for enums that can be constructed from another (usually integral) type
+///
+/// Used with the TryFrom! custom derive macro. Example:
+///
+// FIXME this test can't be run because custom_derive! isn't accessible
+/// ```ignore
+///     #[macro_use] extern crate custom_derive;
+///     use custom_derive::TryFrom;
+///
+///     custom_derive! {
+///         #[derive(Debug, PartialEq, TryFrom(u8))]
+///         enum Get { Up, Down, AllAround }
+///     }
+///
+///     println!("{:?}", Get::try_from(0u8)); // Ok(Get::Up)
+/// ```
 pub trait TryFrom<Src> {
+    /// Error that may be returned from `try_from()`
     type Err;
+
+    /// Convert a value from primitive type to enum variant
     fn try_from(src: Src) -> Result<Self, Self::Err>;
 }
 
 #[macro_export]
+#[doc(hidden)]
 macro_rules! TryFrom {
     (($prim:ty) $(pub)* enum $name:ident { $($body:tt)* }) => {
         TryFrom! {

--- a/src/derives.rs
+++ b/src/derives.rs
@@ -31,6 +31,17 @@ macro_rules! TryFrom {
 
     (
         @collect_variants $fixed:tt,
+        (#[$_attr:meta] $($tail:tt)*) -> $var_names:tt
+    ) => {
+        TryFrom! {
+            @skip_meta $fixed,
+            ($($tail)*) -> $var_names
+        }
+    };
+
+
+    (
+        @collect_variants $fixed:tt,
         ($var:ident $(= $_val:expr)*, $($tail:tt)*) -> ($($var_names:tt)*)
     ) => {
         TryFrom! {
@@ -50,6 +61,26 @@ macro_rules! TryFrom {
             stringify!($var),
             "."
         );
+    };
+
+    (
+        @skip_meta $fixed:tt,
+        (#[$_attr:meta] $($tail:tt)*) -> $var_names:tt
+    ) => {
+        TryFrom! {
+            @skip_meta $fixed,
+            ($($tail)*) -> $var_names
+        }
+    };
+
+    (
+        @skip_meta $fixed:tt,
+        ($var:ident $($tail:tt)*) -> $var_names:tt
+    ) => {
+        TryFrom! {
+            @collect_variants $fixed,
+            ($var $($tail)*) -> $var_names
+        }
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,9 @@ Third, each derivation macro is expected to result in zero or more items, not in
 Finally, `@impl` is merely a trick to pack multiple, different functions into a single macro.  The sequence has no special meaning; it is simply *distinct* from the usual invocation syntax.
 */
 
+#[macro_use] mod derives;
+pub use derives::*;
+
 #[doc(hidden)]
 #[macro_export]
 macro_rules! custom_derive {
@@ -398,3 +401,4 @@ macro_rules! custom_derive {
     */
     (@as_item $($i:item)*) => {$($i)*};
 }
+

--- a/tests/enum_try_from.rs
+++ b/tests/enum_try_from.rs
@@ -1,58 +1,5 @@
 #[macro_use] extern crate custom_derive;
-
-trait TryFrom<Src> {
-    type Err;
-    fn try_from(src: Src) -> Result<Self, Self::Err>;
-}
-
-macro_rules! TryFrom {
-    (($prim:ty) $(pub)* enum $name:ident { $($body:tt)* }) => {
-        TryFrom! {
-            @collect_variants ($name, $prim),
-            ($($body)*,) -> ()
-        }
-    };
-
-    (
-        @collect_variants ($name:ident, $prim:ty),
-        ($(,)*) -> ($($var_names:ident,)*)
-    ) => {
-        impl TryFrom<$prim> for $name {
-            type Err = $prim;
-            fn try_from(src: $prim) -> Result<$name, $prim> {
-                $(
-                    if src == $name::$var_names as $prim {
-                        return Ok($name::$var_names);
-                    }
-                )*
-                Err(src)
-            }
-        }
-    };
-
-    (
-        @collect_variants $fixed:tt,
-        ($var:ident $(= $_val:expr)*, $($tail:tt)*) -> ($($var_names:tt)*)
-    ) => {
-        TryFrom! {
-            @collect_variants $fixed,
-            ($($tail)*) -> ($($var_names)* $var,)
-        }
-    };
-
-    (
-        @collect_variants ($name:ident),
-        ($var:ident $_struct:tt, $($tail:tt)*) -> ($($var_names:tt)*)
-    ) => {
-        const _error: () = concat!(
-            "cannot derive TryFrom for ",
-            stringify!($name),
-            ", due to non-unitary variant ",
-            stringify!($var),
-            "."
-        );
-    };
-}
+use custom_derive::TryFrom;
 
 custom_derive! {
     #[derive(Debug, PartialEq, TryFrom(u8))]

--- a/tests/enum_try_from.rs
+++ b/tests/enum_try_from.rs
@@ -3,7 +3,14 @@ use custom_derive::TryFrom;
 
 custom_derive! {
     #[derive(Debug, PartialEq, TryFrom(u8))]
-    enum Get { Up, Down, AllAround }
+    enum Get {
+        /// The +Z direction
+        Up,
+        /// The -Z direction
+        Down,
+        /// Just... everywhere
+        AllAround
+    }
 }
 
 #[test]


### PR DESCRIPTION
I moved `TryFrom!` from a test to an exported module, documented it, and added two syntax rules to throw out attributes during the `@collect_variants` process. Now that I think about it, the rules I added should be called `@skip_meta` instead of `@collect_meta`. Let me know if you want me to change that. I can also squash these commits if you want.