### PR TITLE
Adding Fmt macro to implement fmt::Display.

### DIFF
--- a/enum_derive/tests/fmt.rs
+++ b/enum_derive/tests/fmt.rs
@@ -1,0 +1,29 @@
+#[macro_use] extern crate custom_derive;
+#[macro_use] extern crate enum_derive;
+
+use ::std::fmt;
+
+custom_derive! {
+    #[derive(Debug, PartialEq, Fmt)]
+    pub enum Get {
+        Up,
+        /// And
+        Down,
+        /** And */
+        AllAround
+    }
+}
+
+custom_derive! {
+    #[derive(Debug, PartialEq, Fmt)]
+    pub enum Degenerate {
+
+    }
+}
+
+#[test]
+fn test_next_variant() {
+    assert_eq!(format!("{}", Get::Up), "Up");
+    assert_eq!(format!("{}", Get::Down), "Down");
+    assert_eq!(format!("{}", Get::AllAround), "AllAround");
+}

--- a/enum_derive/tests/fromstr.rs
+++ b/enum_derive/tests/fromstr.rs
@@ -1,0 +1,29 @@
+#[macro_use] extern crate custom_derive;
+#[macro_use] extern crate enum_derive;
+
+use ::std::str::FromStr;
+
+custom_derive! {
+    #[derive(Debug, PartialEq, FromStr)]
+    pub enum Get {
+        Up,
+        /// And
+        Down,
+        /** And */
+        AllAround
+    }
+}
+
+custom_derive! {
+    #[derive(Debug, PartialEq, FromStr)]
+    pub enum Degenerate {
+
+    }
+}
+
+#[test]
+fn test_next_variant() {
+    assert_eq!(Get::from_str("Up").unwrap(), Get::Up);
+    assert_eq!(Get::from_str("Down").unwrap(), Get::Down);
+    assert_eq!(Get::from_str("AllAround").unwrap(), Get::AllAround);
+}


### PR DESCRIPTION
Pretty self explanatory, I want to add a Fmt macro to enum_derive that implements fmt::Display for unitary Enums and a FromStr macro that implements std::str::FromStr.