### PR TITLE
Move NewtypeSum and Newtype Product out of unstable

### DIFF
--- a/newtype_derive/src/lib.rs
+++ b/newtype_derive/src/lib.rs
@@ -1169,3 +1169,53 @@ macro_rules! NewtypeUpperHex {
         newtype_fmt! { UpperHex, $name }
     };
 }
+
+#[macro_export]
+macro_rules! NewtypeProduct {
+    ($arg:tt $(pub)* struct $name:ident(pub $t0:ty);) => {
+        NewtypeProduct! { $arg struct $name($t0); }
+    };
+
+    (() $(pub)* struct $name:ident($t0:ty);) => {
+        impl ::std::iter::Product<$name> for $name {
+            fn product<I>(iter: I) -> Self
+            where I: Iterator<Item=$name> {
+                $name(iter.map(|e| e.0).product::<$t0>())
+            }
+        }
+    };
+
+    ((&Self) $(pub)* struct $name:ident($t0:ty);) => {
+        impl<'a> ::std::iter::Product<&'a $name> for $name {
+            fn product<I>(iter: I) -> Self
+            where I: Iterator<Item=&'a $name> {
+                $name(iter.map(|e| &e.0).product::<$t0>())
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! NewtypeSum {
+    ($arg:tt $(pub)* struct $name:ident(pub $t0:ty);) => {
+        NewtypeSum! { $arg struct $name($t0); }
+    };
+
+    (() $(pub)* struct $name:ident($t0:ty);) => {
+        impl ::std::iter::Sum<$name> for $name {
+            fn sum<I>(iter: I) -> Self
+            where I: Iterator<Item=$name> {
+                $name(iter.map(|e| e.0).sum::<$t0>())
+            }
+        }
+    };
+
+    ((&Self) $(pub)* struct $name:ident($t0:ty);) => {
+        impl<'a> ::std::iter::Sum<&'a $name> for $name {
+            fn sum<I>(iter: I) -> Self
+            where I: Iterator<Item=&'a $name> {
+                $name(iter.map(|e| &e.0).sum::<$t0>())
+            }
+        }
+    };
+}

--- a/newtype_derive/src/std_unstable.rs
+++ b/newtype_derive/src/std_unstable.rs
@@ -29,56 +29,6 @@ macro_rules! NewtypeOne {
 }
 
 #[macro_export]
-macro_rules! NewtypeProduct {
-    ($arg:tt $(pub)* struct $name:ident(pub $t0:ty);) => {
-        NewtypeProduct! { $arg struct $name($t0); }
-    };
-
-    (() $(pub)* struct $name:ident($t0:ty);) => {
-        impl ::std::iter::Product<$name> for $name {
-            fn product<I>(iter: I) -> Self
-            where I: Iterator<Item=$name> {
-                $name(iter.map(|e| e.0).product::<$t0>())
-            }
-        }
-    };
-
-    ((&Self) $(pub)* struct $name:ident($t0:ty);) => {
-        impl<'a> ::std::iter::Product<&'a $name> for $name {
-            fn product<I>(iter: I) -> Self
-            where I: Iterator<Item=&'a $name> {
-                $name(iter.map(|e| &e.0).product::<$t0>())
-            }
-        }
-    };
-}
-
-#[macro_export]
-macro_rules! NewtypeSum {
-    ($arg:tt $(pub)* struct $name:ident(pub $t0:ty);) => {
-        NewtypeSum! { $arg struct $name($t0); }
-    };
-
-    (() $(pub)* struct $name:ident($t0:ty);) => {
-        impl ::std::iter::Sum<$name> for $name {
-            fn sum<I>(iter: I) -> Self
-            where I: Iterator<Item=$name> {
-                $name(iter.map(|e| e.0).sum::<$t0>())
-            }
-        }
-    };
-
-    ((&Self) $(pub)* struct $name:ident($t0:ty);) => {
-        impl<'a> ::std::iter::Sum<&'a $name> for $name {
-            fn sum<I>(iter: I) -> Self
-            where I: Iterator<Item=&'a $name> {
-                $name(iter.map(|e| &e.0).sum::<$t0>())
-            }
-        }
-    };
-}
-
-#[macro_export]
 macro_rules! NewtypeZero {
     (() $(pub)* struct $name:ident(pub $_t0:ty);) => {
         impl ::std::num::Zero for $name {


### PR DESCRIPTION
Since iter::Sum and iter::Product have been in stable since 1.12, we
can move NewtypeSum and NewtypeProduct from std_unstable.rs to lib.rs.

Signed-off-by: Andy Grover <agrover@redhat.com>