### PR TITLE
add missing fragment specifier

### DIFF
--- a/tests/stable_encodable.rs
+++ b/tests/stable_encodable.rs
@@ -116,7 +116,7 @@ macro_rules! StableEncodable {
 
     (
         @extract_gen_args $fixed:tt,
-        ($ty_name:ident: $($tail)*)
+        ($ty_name:ident: $($tail:tt)*)
         -> bounds($($bounds:tt)*), ty_clss($($ty_clss:tt)*)
     ) => {
         StableEncodable! {


### PR DESCRIPTION
Fixes: https://github.com/DanielKeep/rust-custom-derive/issues/33
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>